### PR TITLE
[bugfix] only calls job.onComplete if defined and adds res as an argument.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -19,9 +19,11 @@ internals.trigger = (server, job) => {
 
         server.log([PluginPackage.name], job.name);
 
-        await server.inject(job.request);
+        const res = await server.inject(job.request);
 
-        job.onComplete();
+        if (typeof job.onComplete === 'function') {
+            job.onComplete();
+        }
     };
 };
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -22,7 +22,7 @@ internals.trigger = (server, job) => {
         const res = await server.inject(job.request);
 
         if (typeof job.onComplete === 'function') {
-            job.onComplete();
+            job.onComplete(res);
         }
     };
 };


### PR DESCRIPTION
Fixed bugs where onComplete was being called each time a job was triggered and where onComplete was being called without passing in the response.