### PR TITLE
Update npm dependencies, switch to lab

### DIFF
--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -4,15 +4,19 @@
 
 const HapiCron = require('../lib');
 const Hapi = require('@hapi/hapi');
+const Code = require('@hapi/code');
+const Lab = require('@hapi/lab');
+const { expect } = Code;
+const lab = exports.lab = Lab.script();
 
 
 /*********************************************************************************
  2. Exports
  *********************************************************************************/
 
-describe('registration assertions', () => {
+lab.test('registration assertions', () => {
 
-    it('should register plugin without errors', async () => {
+    expect('should register plugin wexpecthout errors', async () => {
 
         const server = new Hapi.Server();
 
@@ -21,7 +25,7 @@ describe('registration assertions', () => {
         });
     });
 
-    it('should throw error when a job is defined with an existing name', async () => {
+    expect('should throw error when a job is defined wexpecth an existing name', async () => {
 
         const server = new Hapi.Server();
 
@@ -52,7 +56,7 @@ describe('registration assertions', () => {
         }
     });
 
-    it('should throw error when a job is defined without a name', async () => {
+    expect('should throw error when a job is defined wexpecthout a name', async () => {
 
         const server = new Hapi.Server();
 
@@ -75,7 +79,7 @@ describe('registration assertions', () => {
         }
     });
 
-    it('should throw error when a job is defined without a time', async () => {
+    expect('should throw error when a job is defined wexpecthout a time', async () => {
 
         const server = new Hapi.Server();
 
@@ -98,7 +102,7 @@ describe('registration assertions', () => {
         }
     });
 
-    it('should throw error when a job is defined with an invalid time', async () => {
+    expect('should throw error when a job is defined wexpecth an invalid time', async () => {
 
         const server = new Hapi.Server();
 
@@ -122,7 +126,7 @@ describe('registration assertions', () => {
         }
     });
 
-    it('should throw error when a job is defined with an invalid timezone', async () => {
+    expect('should throw error when a job is defined wexpecth an invalid timezone', async () => {
 
         const server = new Hapi.Server();
 
@@ -146,7 +150,7 @@ describe('registration assertions', () => {
         }
     });
 
-    it('should throw error when a job is defined without a timezone', async () => {
+    expect('should throw error when a job is defined wexpecthout a timezone', async () => {
 
         const server = new Hapi.Server();
 
@@ -169,7 +173,7 @@ describe('registration assertions', () => {
         }
     });
 
-    it('should throw error when a job is defined without a request object', async () => {
+    expect('should throw error when a job is defined wexpecthout a request object', async () => {
 
         const server = new Hapi.Server();
 
@@ -190,7 +194,7 @@ describe('registration assertions', () => {
         }
     });
 
-    it('should throw error when a job is defined without a url in the request object', async () => {
+    expect('should throw error when a job is defined wexpecthout a url in the request object', async () => {
 
         const server = new Hapi.Server();
 
@@ -214,7 +218,7 @@ describe('registration assertions', () => {
         }
     });
 
-    it('should throw error when a job is defined with an invalid onComplete value', async () => {
+    expect('should throw error when a job is defined wexpecth an invalid onComplete value', async () => {
 
         const server = new Hapi.Server();
 
@@ -241,9 +245,9 @@ describe('registration assertions', () => {
     });
 });
 
-describe('plugin functionality', () => {
+lab.test('plugin functionalexpecty', () => {
 
-    it('should expose access to the registered jobs', async () => {
+    expect('should expose access to the registered jobs', async () => {
 
         const server = new Hapi.Server();
 
@@ -266,7 +270,7 @@ describe('plugin functionality', () => {
         expect(server.plugins['hapi-cron'].jobs.testcron).toBeDefined();
     });
 
-    it('should ensure the request and callback from the plugin options are triggered', async (done) => {
+    expect('should ensure the request and callback from the plugin options are triggered', async (done) => {
 
         const onComplete = jest.fn();
         const server = new Hapi.Server();
@@ -305,10 +309,10 @@ describe('plugin functionality', () => {
         await server.plugins['hapi-cron'].jobs.testcron._callbacks[0]();
 
         expect(onComplete).toHaveBeenCalledTimes(1);
-        expect(onComplete).toHaveBeenCalledWith('hello world');
+        expect(onComplete).toHaveBeenCalledWexpecth('hello world');
     });
 
-    it('should not start the jobs until the server starts', async () => {
+    expect('should not start the jobs until the server starts', async () => {
 
         const server = new Hapi.Server();
 
@@ -336,7 +340,7 @@ describe('plugin functionality', () => {
         await server.stop();
     });
 
-    it('should stop cron jobs when the server stops', async () => {
+    expect('should stop cron jobs when the server stops', async () => {
 
         const server = new Hapi.Server();
 

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -16,7 +16,7 @@ const lab = exports.lab = Lab.script();
 
 lab.test('registration assertions', () => {
 
-    expect('should register plugin wexpecthout errors', async () => {
+    expect('should register plugin without errors', async () => {
 
         const server = new Hapi.Server();
 
@@ -25,7 +25,7 @@ lab.test('registration assertions', () => {
         });
     });
 
-    expect('should throw error when a job is defined wexpecth an existing name', async () => {
+    expect('should throw error when a job is defined with an existing name', async () => {
 
         const server = new Hapi.Server();
 
@@ -56,7 +56,7 @@ lab.test('registration assertions', () => {
         }
     });
 
-    expect('should throw error when a job is defined wexpecthout a name', async () => {
+    expect('should throw error when a job is defined without a name', async () => {
 
         const server = new Hapi.Server();
 
@@ -79,7 +79,7 @@ lab.test('registration assertions', () => {
         }
     });
 
-    expect('should throw error when a job is defined wexpecthout a time', async () => {
+    expect('should throw error when a job is defined without a time', async () => {
 
         const server = new Hapi.Server();
 
@@ -102,7 +102,7 @@ lab.test('registration assertions', () => {
         }
     });
 
-    expect('should throw error when a job is defined wexpecth an invalid time', async () => {
+    expect('should throw error when a job is defined with an invalid time', async () => {
 
         const server = new Hapi.Server();
 
@@ -126,7 +126,7 @@ lab.test('registration assertions', () => {
         }
     });
 
-    expect('should throw error when a job is defined wexpecth an invalid timezone', async () => {
+    expect('should throw error when a job is defined with an invalid timezone', async () => {
 
         const server = new Hapi.Server();
 
@@ -150,7 +150,7 @@ lab.test('registration assertions', () => {
         }
     });
 
-    expect('should throw error when a job is defined wexpecthout a timezone', async () => {
+    expect('should throw error when a job is defined without a timezone', async () => {
 
         const server = new Hapi.Server();
 
@@ -173,7 +173,7 @@ lab.test('registration assertions', () => {
         }
     });
 
-    expect('should throw error when a job is defined wexpecthout a request object', async () => {
+    expect('should throw error when a job is defined without a request object', async () => {
 
         const server = new Hapi.Server();
 
@@ -194,7 +194,7 @@ lab.test('registration assertions', () => {
         }
     });
 
-    expect('should throw error when a job is defined wexpecthout a url in the request object', async () => {
+    expect('should throw error when a job is defined without a url in the request object', async () => {
 
         const server = new Hapi.Server();
 
@@ -218,7 +218,7 @@ lab.test('registration assertions', () => {
         }
     });
 
-    expect('should throw error when a job is defined wexpecth an invalid onComplete value', async () => {
+    expect('should throw error when a job is defined with an invalid onComplete value', async () => {
 
         const server = new Hapi.Server();
 
@@ -309,7 +309,7 @@ lab.test('plugin functionalexpecty', () => {
         await server.plugins['hapi-cron'].jobs.testcron._callbacks[0]();
 
         expect(onComplete).toHaveBeenCalledTimes(1);
-        expect(onComplete).toHaveBeenCalledWexpecth('hello world');
+        expect(onComplete).toHaveBeenCalledwith('hello world');
     });
 
     expect('should not start the jobs until the server starts', async () => {

--- a/package.json
+++ b/package.json
@@ -23,15 +23,16 @@
   },
   "homepage": "https://github.com/antonsamper/hapi-cron#readme",
   "devDependencies": {
-    "eslint": "^6.0.0",
+    "@hapi/code": "^8.0.1",
     "@hapi/eslint-config-hapi": "^12.1.0",
     "@hapi/eslint-plugin-hapi": "^4.3.3",
     "@hapi/hapi": "^18.3.1",
-    "jest": "^24.8.0"
+    "@hapi/lab": "^22.0.3",
+    "eslint": "^6.0.0"
   },
   "dependencies": {
-    "cron": "^1.7.1",
-    "@hapi/hoek": "^7.2.0"
+    "cron": "^1.8.2",
+    "@hapi/hoek": "^9.0.3"
   },
   "engines": {
     "node": ">=8.0.0"


### PR DESCRIPTION
### Getting errors pulling down the npm package for `hapi-cron`.

Updated the dependencies and switched from `jest` (which seems to be installed globally) was not working over to `@hapi/lab` which is awesome and has no dependencies and your tests ran without issue


### Details from package download listed below
```
0 info it worked if it ends with ok
1 verbose cli [
1 verbose cli   '/usr/local/Cellar/node/13.7.0/bin/node',
1 verbose cli   '/usr/local/bin/npm',
1 verbose cli   'install',
1 verbose cli   '--save',
1 verbose cli   'hapi-cron'
1 verbose cli ]
2 info using npm@6.13.6
3 info using node@v13.7.0
4 verbose npm-session d173b094915e36e6
5 silly install loadCurrentTree
6 silly install readLocalPackageData
7 http fetch GET 200 https://registry.npmjs.org/hapi-cron 26ms (from cache)
8 silly pacote tag manifest for hapi-cron@latest fetched in 46ms
9 timing stage:loadCurrentTree Completed in 1044ms
10 silly install loadIdealTree
11 silly install cloneCurrentTreeToIdealTree
12 timing stage:loadIdealTree:cloneCurrentTree Completed in 6ms
13 silly install loadShrinkwrap
14 timing stage:rollbackFailedOptional Completed in 0ms
15 timing stage:runTopLevelLifecycles Completed in 1056ms
16 silly saveTree ercot-market@0.0.1
16 silly saveTree ├─┬ @hapi/hapi@18.4.0
16 silly saveTree │ ├─┬ @hapi/accept@3.2.3
16 silly saveTree │ │ ├─┬ @hapi/boom@7.4.11
16 silly saveTree │ │ │ └── @hapi/hoek@8.5.0
16 silly saveTree │ │ └── @hapi/hoek@8.5.0
16 silly saveTree │ ├── @hapi/ammo@3.1.1
16 silly saveTree │ ├── @hapi/boom@7.4.11
16 silly saveTree │ ├── @hapi/bounce@1.3.2
16 silly saveTree │ ├── @hapi/call@5.1.2
16 silly saveTree │ ├── @hapi/catbox-memory@4.1.1
16 silly saveTree │ ├─┬ @hapi/catbox@10.2.3
16 silly saveTree │ │ ├─┬ @hapi/joi@16.1.8
16 silly saveTree │ │ │ ├── @hapi/address@2.1.4
16 silly saveTree │ │ │ ├── @hapi/formula@1.2.0
16 silly saveTree │ │ │ ├── @hapi/pinpoint@1.0.2
16 silly saveTree │ │ │ └── @hapi/topo@3.1.6
16 silly saveTree │ │ └─┬ @hapi/podium@3.4.3
16 silly saveTree │ │   └── @hapi/joi@16.1.8
16 silly saveTree │ ├─┬ @hapi/heavy@6.2.2
16 silly saveTree │ │ └── @hapi/joi@16.1.8
16 silly saveTree │ ├── @hapi/hoek@8.5.0
16 silly saveTree │ ├─┬ @hapi/joi@15.1.1
16 silly saveTree │ │ └── @hapi/bourne@1.3.2
16 silly saveTree │ ├─┬ @hapi/mimos@4.1.1
16 silly saveTree │ │ └── mime-db@1.42.0
16 silly saveTree │ ├── @hapi/podium@3.4.3
16 silly saveTree │ ├─┬ @hapi/shot@4.1.2
16 silly saveTree │ │ └── @hapi/joi@16.1.8
16 silly saveTree │ ├── @hapi/somever@2.1.1
16 silly saveTree │ ├─┬ @hapi/statehood@6.1.2
16 silly saveTree │ │ ├── @hapi/cryptiles@4.2.1
16 silly saveTree │ │ ├─┬ @hapi/iron@5.1.4
16 silly saveTree │ │ │ └── @hapi/b64@4.2.1
16 silly saveTree │ │ └── @hapi/joi@16.1.8
16 silly saveTree │ ├─┬ @hapi/subtext@6.1.2
16 silly saveTree │ │ ├── @hapi/content@4.1.0
16 silly saveTree │ │ ├── @hapi/file@1.0.0
16 silly saveTree │ │ ├─┬ @hapi/pez@4.1.1
16 silly saveTree │ │ │ └─┬ @hapi/nigel@3.1.1
16 silly saveTree │ │ │   └── @hapi/vise@3.1.1
16 silly saveTree │ │ └── @hapi/wreck@15.1.0
16 silly saveTree │ ├── @hapi/teamwork@3.3.1
16 silly saveTree │ └── @hapi/topo@3.1.6
16 silly saveTree ├── @hapi/joi@16.1.8
16 silly saveTree ├─┬ async-csv@2.1.3
16 silly saveTree │ └─┬ csv@5.3.1
16 silly saveTree │   ├── csv-generate@3.2.4
16 silly saveTree │   ├── csv-parse@4.8.3
16 silly saveTree │   ├── csv-stringify@5.3.6
16 silly saveTree │   └─┬ stream-transform@2.0.1
16 silly saveTree │     └── mixme@0.3.5
16 silly saveTree ├─┬ axios@0.19.0
16 silly saveTree │ ├─┬ follow-redirects@1.5.10
16 silly saveTree │ │ └─┬ debug@3.1.0
16 silly saveTree │ │   └── ms@2.0.0
16 silly saveTree │ └── is-buffer@2.0.4
16 silly saveTree ├─┬ content-disposition@0.5.3
16 silly saveTree │ └── safe-buffer@5.1.2
16 silly saveTree ├── csv@5.3.1
16 silly saveTree ├─┬ csvtojson@2.0.10
16 silly saveTree │ ├── bluebird@3.7.2
16 silly saveTree │ ├── lodash@4.17.15
16 silly saveTree │ └─┬ strip-bom@2.0.0
16 silly saveTree │   └── is-utf8@0.2.1
16 silly saveTree ├─┬ fs-extra@8.1.0
16 silly saveTree │ ├── graceful-fs@4.2.3
16 silly saveTree │ ├── jsonfile@4.0.0
16 silly saveTree │ └── universalify@0.1.2
16 silly saveTree ├─┬ hapi-auto-route@3.0.4
16 silly saveTree │ ├── @hapi/joi@15.1.1
16 silly saveTree │ └─┬ glob@7.1.6
16 silly saveTree │   ├── fs.realpath@1.0.0
16 silly saveTree │   ├─┬ inflight@1.0.6
16 silly saveTree │   │ ├─┬ once@1.4.0
16 silly saveTree │   │ │ └── wrappy@1.0.2
16 silly saveTree │   │ └── wrappy@1.0.2
16 silly saveTree │   ├── inherits@2.0.4
16 silly saveTree │   ├─┬ minimatch@3.0.4
16 silly saveTree │   │ └─┬ brace-expansion@1.1.11
16 silly saveTree │   │   ├── balanced-match@1.0.0
16 silly saveTree │   │   └── concat-map@0.0.1
16 silly saveTree │   ├── once@1.4.0
16 silly saveTree │   └── path-is-absolute@1.0.1
16 silly saveTree ├─┬ jssoup@0.0.10
16 silly saveTree │ ├─┬ debug@2.6.9
16 silly saveTree │ │ └── ms@2.0.0
16 silly saveTree │ ├── growl@1.10.5
16 silly saveTree │ └── htmlparser@1.7.7
16 silly saveTree ├─┬ knex@0.20.6
16 silly saveTree │ ├── colorette@1.1.0
16 silly saveTree │ ├── commander@4.0.1
16 silly saveTree │ ├─┬ debug@4.1.1
16 silly saveTree │ │ └── ms@2.1.2
16 silly saveTree │ ├── getopts@2.2.5
16 silly saveTree │ ├── interpret@2.0.0
16 silly saveTree │ ├─┬ liftoff@3.1.0
16 silly saveTree │ │ ├── extend@3.0.2
16 silly saveTree │ │ ├─┬ findup-sync@3.0.0
16 silly saveTree │ │ │ ├── detect-file@1.0.0
16 silly saveTree │ │ │ ├─┬ is-glob@4.0.1
16 silly saveTree │ │ │ │ └── is-extglob@2.1.1
16 silly saveTree │ │ │ ├─┬ micromatch@3.1.10
16 silly saveTree │ │ │ │ ├── arr-diff@4.0.0
16 silly saveTree │ │ │ │ ├── array-unique@0.3.2
16 silly saveTree │ │ │ │ ├─┬ braces@2.3.2
16 silly saveTree │ │ │ │ │ ├── arr-flatten@1.1.0
16 silly saveTree │ │ │ │ │ ├─┬ extend-shallow@2.0.1
16 silly saveTree │ │ │ │ │ │ └── is-extendable@0.1.1
16 silly saveTree │ │ │ │ │ ├─┬ fill-range@4.0.0
16 silly saveTree │ │ │ │ │ │ ├── extend-shallow@2.0.1
16 silly saveTree │ │ │ │ │ │ ├─┬ is-number@3.0.0
16 silly saveTree │ │ │ │ │ │ │ └─┬ kind-of@3.2.2
16 silly saveTree │ │ │ │ │ │ │   └── is-buffer@1.1.6
16 silly saveTree │ │ │ │ │ │ ├── repeat-string@1.6.1
16 silly saveTree │ │ │ │ │ │ └── to-regex-range@2.1.1
16 silly saveTree │ │ │ │ │ ├── isobject@3.0.1
16 silly saveTree │ │ │ │ │ ├── repeat-element@1.1.3
16 silly saveTree │ │ │ │ │ ├─┬ snapdragon-node@2.1.1
16 silly saveTree │ │ │ │ │ │ ├─┬ define-property@1.0.0
16 silly saveTree │ │ │ │ │ │ │ └─┬ is-descriptor@1.0.2
16 silly saveTree │ │ │ │ │ │ │   ├─┬ is-accessor-descriptor@1.0.0
16 silly saveTree │ │ │ │ │ │ │   │ └── kind-of@6.0.2
16 silly saveTree │ │ │ │ │ │ │   ├── is-data-descriptor@1.0.0
16 silly saveTree │ │ │ │ │ │ │   └── kind-of@6.0.2
16 silly saveTree │ │ │ │ │ │ └─┬ snapdragon-util@3.0.1
16 silly saveTree │ │ │ │ │ │   └── kind-of@3.2.2
16 silly saveTree │ │ │ │ │ ├─┬ snapdragon@0.8.2
16 silly saveTree │ │ │ │ │ │ ├─┬ base@0.11.2
16 silly saveTree │ │ │ │ │ │ │ ├─┬ cache-base@1.0.1
16 silly saveTree │ │ │ │ │ │ │ │ ├─┬ collection-visit@1.0.0
16 silly saveTree │ │ │ │ │ │ │ │ │ ├─┬ map-visit@1.0.0
16 silly saveTree │ │ │ │ │ │ │ │ │ │ └── object-visit@1.0.1
16 silly saveTree │ │ │ │ │ │ │ │ │ └── object-visit@1.0.1
16 silly saveTree │ │ │ │ │ │ │ │ ├── component-emitter@1.3.0
16 silly saveTree │ │ │ │ │ │ │ │ ├── get-value@2.0.6
16 silly saveTree │ │ │ │ │ │ │ │ ├─┬ has-value@1.0.0
16 silly saveTree │ │ │ │ │ │ │ │ │ └─┬ has-values@1.0.0
16 silly saveTree │ │ │ │ │ │ │ │ │   └── kind-of@4.0.0
16 silly saveTree │ │ │ │ │ │ │ │ ├─┬ set-value@2.0.1
16 silly saveTree │ │ │ │ │ │ │ │ │ ├── extend-shallow@2.0.1
16 silly saveTree │ │ │ │ │ │ │ │ │ ├── is-plain-object@2.0.4
16 silly saveTree │ │ │ │ │ │ │ │ │ └─┬ split-string@3.1.0
16 silly saveTree │ │ │ │ │ │ │ │ │   └─┬ extend-shallow@3.0.2
16 silly saveTree │ │ │ │ │ │ │ │ │     ├── assign-symbols@1.0.0
16 silly saveTree │ │ │ │ │ │ │ │ │     └── is-extendable@1.0.1
16 silly saveTree │ │ │ │ │ │ │ │ ├─┬ to-object-path@0.3.0
16 silly saveTree │ │ │ │ │ │ │ │ │ └── kind-of@3.2.2
16 silly saveTree │ │ │ │ │ │ │ │ ├─┬ union-value@1.0.1
16 silly saveTree │ │ │ │ │ │ │ │ │ └── arr-union@3.1.0
16 silly saveTree │ │ │ │ │ │ │ │ └─┬ unset-value@1.0.0
16 silly saveTree │ │ │ │ │ │ │ │   └─┬ has-value@0.3.1
16 silly saveTree │ │ │ │ │ │ │ │     ├── has-values@0.1.4
16 silly saveTree │ │ │ │ │ │ │ │     └─┬ isobject@2.1.0
16 silly saveTree │ │ │ │ │ │ │ │       └── isarray@1.0.0
16 silly saveTree │ │ │ │ │ │ │ ├─┬ class-utils@0.3.6
16 silly saveTree │ │ │ │ │ │ │ │ ├─┬ define-property@0.2.5
16 silly saveTree │ │ │ │ │ │ │ │ │ └─┬ is-descriptor@0.1.6
16 silly saveTree │ │ │ │ │ │ │ │ │   ├─┬ is-accessor-descriptor@0.1.6
16 silly saveTree │ │ │ │ │ │ │ │ │   │ └── kind-of@3.2.2
16 silly saveTree │ │ │ │ │ │ │ │ │   ├─┬ is-data-descriptor@0.1.4
16 silly saveTree │ │ │ │ │ │ │ │ │   │ └── kind-of@3.2.2
16 silly saveTree │ │ │ │ │ │ │ │ │   └── kind-of@5.1.0
16 silly saveTree │ │ │ │ │ │ │ │ └─┬ static-extend@0.1.2
16 silly saveTree │ │ │ │ │ │ │ │   ├── define-property@0.2.5
16 silly saveTree │ │ │ │ │ │ │ │   └─┬ object-copy@0.1.0
16 silly saveTree │ │ │ │ │ │ │ │     ├── copy-descriptor@0.1.1
16 silly saveTree │ │ │ │ │ │ │ │     ├── define-property@0.2.5
16 silly saveTree │ │ │ │ │ │ │ │     └── kind-of@3.2.2
16 silly saveTree │ │ │ │ │ │ │ ├── component-emitter@1.3.0
16 silly saveTree │ │ │ │ │ │ │ ├─┬ define-property@1.0.0
16 silly saveTree │ │ │ │ │ │ │ │ └─┬ is-descriptor@1.0.2
16 silly saveTree │ │ │ │ │ │ │ │   ├── is-accessor-descriptor@1.0.0
16 silly saveTree │ │ │ │ │ │ │ │   └── is-data-descriptor@1.0.0
16 silly saveTree │ │ │ │ │ │ │ ├─┬ mixin-deep@1.3.2
16 silly saveTree │ │ │ │ │ │ │ │ ├── for-in@1.0.2
16 silly saveTree │ │ │ │ │ │ │ │ └── is-extendable@1.0.1
16 silly saveTree │ │ │ │ │ │ │ └── pascalcase@0.1.1
16 silly saveTree │ │ │ │ │ │ ├─┬ debug@2.6.9
16 silly saveTree │ │ │ │ │ │ │ └── ms@2.0.0
16 silly saveTree │ │ │ │ │ │ ├── define-property@0.2.5
16 silly saveTree │ │ │ │ │ │ ├── extend-shallow@2.0.1
16 silly saveTree │ │ │ │ │ │ ├── map-cache@0.2.2
16 silly saveTree │ │ │ │ │ │ ├─┬ source-map-resolve@0.5.3
16 silly saveTree │ │ │ │ │ │ │ ├── atob@2.1.2
16 silly saveTree │ │ │ │ │ │ │ ├── decode-uri-component@0.2.0
16 silly saveTree │ │ │ │ │ │ │ ├── resolve-url@0.2.1
16 silly saveTree │ │ │ │ │ │ │ ├── source-map-url@0.4.0
16 silly saveTree │ │ │ │ │ │ │ └── urix@0.1.0
16 silly saveTree │ │ │ │ │ │ ├── source-map@0.5.7
16 silly saveTree │ │ │ │ │ │ └── use@3.1.1
16 silly saveTree │ │ │ │ │ ├── split-string@3.1.0
16 silly saveTree │ │ │ │ │ └─┬ to-regex@3.0.2
16 silly saveTree │ │ │ │ │   ├─┬ define-property@2.0.2
16 silly saveTree │ │ │ │ │   │ └─┬ is-descriptor@1.0.2
16 silly saveTree │ │ │ │ │   │   ├── is-accessor-descriptor@1.0.0
16 silly saveTree │ │ │ │ │   │   └── is-data-descriptor@1.0.0
16 silly saveTree │ │ │ │ │   ├─┬ regex-not@1.0.2
16 silly saveTree │ │ │ │ │   │ └─┬ safe-regex@1.1.0
16 silly saveTree │ │ │ │ │   │   └── ret@0.1.15
16 silly saveTree │ │ │ │ │   └── safe-regex@1.1.0
16 silly saveTree │ │ │ │ ├── define-property@2.0.2
16 silly saveTree │ │ │ │ ├── extend-shallow@3.0.2
16 silly saveTree │ │ │ │ ├─┬ extglob@2.0.4
16 silly saveTree │ │ │ │ │ ├─┬ define-property@1.0.0
16 silly saveTree │ │ │ │ │ │ └─┬ is-descriptor@1.0.2
16 silly saveTree │ │ │ │ │ │   ├── is-accessor-descriptor@1.0.0
16 silly saveTree │ │ │ │ │ │   └── is-data-descriptor@1.0.0
16 silly saveTree │ │ │ │ │ ├─┬ expand-brackets@2.1.4
16 silly saveTree │ │ │ │ │ │ ├─┬ debug@2.6.9
16 silly saveTree │ │ │ │ │ │ │ └── ms@2.0.0
16 silly saveTree │ │ │ │ │ │ ├── define-property@0.2.5
16 silly saveTree │ │ │ │ │ │ ├── extend-shallow@2.0.1
16 silly saveTree │ │ │ │ │ │ └── posix-character-classes@0.1.1
16 silly saveTree │ │ │ │ │ ├── extend-shallow@2.0.1
16 silly saveTree │ │ │ │ │ └── fragment-cache@0.2.1
16 silly saveTree │ │ │ │ ├── fragment-cache@0.2.1
16 silly saveTree │ │ │ │ ├── kind-of@6.0.2
16 silly saveTree │ │ │ │ ├─┬ nanomatch@1.2.13
16 silly saveTree │ │ │ │ │ ├── is-windows@1.0.2
16 silly saveTree │ │ │ │ │ └── object.pick@1.3.0
16 silly saveTree │ │ │ │ ├── object.pick@1.3.0
16 silly saveTree │ │ │ │ ├── regex-not@1.0.2
16 silly saveTree │ │ │ │ ├── snapdragon@0.8.2
16 silly saveTree │ │ │ │ └── to-regex@3.0.2
16 silly saveTree │ │ │ └─┬ resolve-dir@1.0.1
16 silly saveTree │ │ │   ├─┬ expand-tilde@2.0.2
16 silly saveTree │ │ │   │ └─┬ homedir-polyfill@1.0.3
16 silly saveTree │ │ │   │   └── parse-passwd@1.0.0
16 silly saveTree │ │ │   └─┬ global-modules@1.0.0
16 silly saveTree │ │ │     └─┬ global-prefix@1.0.2
16 silly saveTree │ │ │       ├── ini@1.3.5
16 silly saveTree │ │ │       └─┬ which@1.3.1
16 silly saveTree │ │ │         └── isexe@2.0.0
16 silly saveTree │ │ ├─┬ fined@1.2.0
16 silly saveTree │ │ │ ├─┬ object.defaults@1.1.0
16 silly saveTree │ │ │ │ ├── array-each@1.0.1
16 silly saveTree │ │ │ │ ├── array-slice@1.1.0
16 silly saveTree │ │ │ │ └── for-own@1.0.0
16 silly saveTree │ │ │ └─┬ parse-filepath@1.0.2
16 silly saveTree │ │ │   ├─┬ is-absolute@1.0.0
16 silly saveTree │ │ │   │ └─┬ is-relative@1.0.0
16 silly saveTree │ │ │   │   └─┬ is-unc-path@1.0.0
16 silly saveTree │ │ │   │     └── unc-path-regex@0.1.2
16 silly saveTree │ │ │   └─┬ path-root@0.1.1
16 silly saveTree │ │ │     └── path-root-regex@0.1.2
16 silly saveTree │ │ ├── flagged-respawn@1.0.1
16 silly saveTree │ │ ├── is-plain-object@2.0.4
16 silly saveTree │ │ ├─┬ object.map@1.0.1
16 silly saveTree │ │ │ └── make-iterator@1.0.1
16 silly saveTree │ │ ├─┬ rechoir@0.6.2
16 silly saveTree │ │ │ └─┬ resolve@1.14.1
16 silly saveTree │ │ │   └── path-parse@1.0.6
16 silly saveTree │ │ └── resolve@1.14.1
16 silly saveTree │ ├─┬ mkdirp@0.5.1
16 silly saveTree │ │ └── minimist@0.0.8
16 silly saveTree │ ├── pg-connection-string@2.1.0
16 silly saveTree │ ├── tarn@2.0.0
16 silly saveTree │ ├── tildify@2.0.0
16 silly saveTree │ ├── uuid@3.3.3
16 silly saveTree │ └── v8flags@3.1.3
16 silly saveTree ├── luxon@1.22.0
16 silly saveTree ├─┬ sqlite3@4.1.1
16 silly saveTree │ ├── nan@2.14.0
16 silly saveTree │ ├─┬ node-pre-gyp@0.11.0
16 silly saveTree │ │ ├── detect-libc@1.0.3
16 silly saveTree │ │ ├─┬ needle@2.4.0
16 silly saveTree │ │ │ ├── debug@3.2.6
16 silly saveTree │ │ │ ├─┬ iconv-lite@0.4.24
16 silly saveTree │ │ │ │ └── safer-buffer@2.1.2
16 silly saveTree │ │ │ └── sax@1.2.4
16 silly saveTree │ │ ├─┬ nopt@4.0.1
16 silly saveTree │ │ │ ├── abbrev@1.1.1
16 silly saveTree │ │ │ └─┬ osenv@0.1.5
16 silly saveTree │ │ │   ├── os-homedir@1.0.2
16 silly saveTree │ │ │   └── os-tmpdir@1.0.2
16 silly saveTree │ │ ├─┬ npm-packlist@1.4.7
16 silly saveTree │ │ │ ├── ignore-walk@3.0.3
16 silly saveTree │ │ │ └─┬ npm-bundled@1.1.1
16 silly saveTree │ │ │   └── npm-normalize-package-bin@1.0.1
16 silly saveTree │ │ ├─┬ npmlog@4.1.2
16 silly saveTree │ │ │ ├─┬ are-we-there-yet@1.1.5
16 silly saveTree │ │ │ │ ├── delegates@1.0.0
16 silly saveTree │ │ │ │ └─┬ readable-stream@2.3.6
16 silly saveTree │ │ │ │   ├── core-util-is@1.0.2
16 silly saveTree │ │ │ │   ├── process-nextick-args@2.0.1
16 silly saveTree │ │ │ │   ├── string_decoder@1.1.1
16 silly saveTree │ │ │ │   └── util-deprecate@1.0.2
16 silly saveTree │ │ │ ├── console-control-strings@1.1.0
16 silly saveTree │ │ │ ├─┬ gauge@2.7.4
16 silly saveTree │ │ │ │ ├── aproba@1.2.0
16 silly saveTree │ │ │ │ ├── has-unicode@2.0.1
16 silly saveTree │ │ │ │ ├── object-assign@4.1.1
16 silly saveTree │ │ │ │ ├── signal-exit@3.0.2
16 silly saveTree │ │ │ │ ├─┬ string-width@1.0.2
16 silly saveTree │ │ │ │ │ ├── code-point-at@1.1.0
16 silly saveTree │ │ │ │ │ ├─┬ is-fullwidth-code-point@1.0.0
16 silly saveTree │ │ │ │ │ │ └── number-is-nan@1.0.1
16 silly saveTree │ │ │ │ │ └─┬ strip-ansi@3.0.1
16 silly saveTree │ │ │ │ │   └── ansi-regex@2.1.1
16 silly saveTree │ │ │ │ ├── strip-ansi@3.0.1
16 silly saveTree │ │ │ │ └── wide-align@1.1.3
16 silly saveTree │ │ │ └── set-blocking@2.0.0
16 silly saveTree │ │ ├─┬ rc@1.2.8
16 silly saveTree │ │ │ ├── deep-extend@0.6.0
16 silly saveTree │ │ │ ├── minimist@1.2.0
16 silly saveTree │ │ │ └── strip-json-comments@2.0.1
16 silly saveTree │ │ ├── rimraf@2.7.1
16 silly saveTree │ │ ├── semver@5.7.1
16 silly saveTree │ │ └─┬ tar@4.4.13
16 silly saveTree │ │   ├── chownr@1.1.3
16 silly saveTree │ │   ├─┬ fs-minipass@1.2.7
16 silly saveTree │ │   │ └─┬ minipass@2.9.0
16 silly saveTree │ │   │   └── yallist@3.1.1
16 silly saveTree │ │   ├── minipass@2.9.0
16 silly saveTree │ │   ├── minizlib@1.3.3
16 silly saveTree │ │   └── yallist@3.1.1
16 silly saveTree │ └─┬ request@2.88.0
16 silly saveTree │   ├── aws-sign2@0.7.0
16 silly saveTree │   ├── aws4@1.9.0
16 silly saveTree │   ├── caseless@0.12.0
16 silly saveTree │   ├─┬ combined-stream@1.0.8
16 silly saveTree │   │ └── delayed-stream@1.0.0
16 silly saveTree │   ├── forever-agent@0.6.1
16 silly saveTree │   ├─┬ form-data@2.3.3
16 silly saveTree │   │ ├── asynckit@0.4.0
16 silly saveTree │   │ └── mime-types@2.1.25
16 silly saveTree │   ├─┬ har-validator@5.1.3
16 silly saveTree │   │ ├─┬ ajv@6.10.2
16 silly saveTree │   │ │ ├── fast-deep-equal@2.0.1
16 silly saveTree │   │ │ ├── fast-json-stable-stringify@2.1.0
16 silly saveTree │   │ │ ├── json-schema-traverse@0.4.1
16 silly saveTree │   │ │ └─┬ uri-js@4.2.2
16 silly saveTree │   │ │   └── punycode@2.1.1
16 silly saveTree │   │ └── har-schema@2.0.0
16 silly saveTree │   ├─┬ http-signature@1.2.0
16 silly saveTree │   │ ├── assert-plus@1.0.0
16 silly saveTree │   │ ├─┬ jsprim@1.4.1
16 silly saveTree │   │ │ ├── extsprintf@1.3.0
16 silly saveTree │   │ │ ├── json-schema@0.2.3
16 silly saveTree │   │ │ └── verror@1.10.0
16 silly saveTree │   │ └─┬ sshpk@1.16.1
16 silly saveTree │   │   ├── asn1@0.2.4
16 silly saveTree │   │   ├─┬ bcrypt-pbkdf@1.0.2
16 silly saveTree │   │   │ └── tweetnacl@0.14.5
16 silly saveTree │   │   ├── dashdash@1.14.1
16 silly saveTree │   │   ├─┬ ecc-jsbn@0.1.2
16 silly saveTree │   │   │ └── jsbn@0.1.1
16 silly saveTree │   │   ├── getpass@0.1.7
16 silly saveTree │   │   ├── jsbn@0.1.1
16 silly saveTree │   │   └── tweetnacl@0.14.5
16 silly saveTree │   ├── is-typedarray@1.0.0
16 silly saveTree │   ├── isstream@0.1.2
16 silly saveTree │   ├── json-stringify-safe@5.0.1
16 silly saveTree │   ├── mime-types@2.1.25
16 silly saveTree │   ├── oauth-sign@0.9.0
16 silly saveTree │   ├── performance-now@2.1.0
16 silly saveTree │   ├── qs@6.5.2
16 silly saveTree │   ├─┬ tough-cookie@2.4.3
16 silly saveTree │   │ ├── psl@1.7.0
16 silly saveTree │   │ └── punycode@1.4.1
16 silly saveTree │   └── tunnel-agent@0.6.0
16 silly saveTree ├─┬ temp-write@4.0.0
16 silly saveTree │ ├── is-stream@2.0.0
16 silly saveTree │ ├─┬ make-dir@3.0.0
16 silly saveTree │ │ └── semver@6.3.0
16 silly saveTree │ └── temp-dir@1.0.0
16 silly saveTree └─┬ unzip-simple@1.0.4
16 silly saveTree   ├─┬ micromatch@4.0.2
16 silly saveTree   │ ├─┬ braces@3.0.2
16 silly saveTree   │ │ └─┬ fill-range@7.0.1
16 silly saveTree   │ │   └─┬ to-regex-range@5.0.1
16 silly saveTree   │ │     └── is-number@7.0.0
16 silly saveTree   │ └── picomatch@2.2.1
16 silly saveTree   └─┬ yauzl@2.10.0
16 silly saveTree     ├── buffer-crc32@0.2.13
16 silly saveTree     └─┬ fd-slicer@1.1.0
16 silly saveTree       └── pend@1.2.0
17 verbose stack SyntaxError: Unexpected end of JSON input while parsing near '...
17 verbose stack       }
17 verbose stack     }
17 verbose stack   }
17 verbose stack }
17 verbose stack '
17 verbose stack     at JSON.parse (<anonymous>)
17 verbose stack     at parseJson (/usr/local/lib/node_modules/npm/node_modules/json-parse-better-errors/index.js:7:17)
17 verbose stack     at module.exports (/usr/local/lib/node_modules/npm/lib/utils/parse-json.js:4:10)
17 verbose stack     at parsePkgLock (/usr/local/lib/node_modules/npm/lib/install/read-shrinkwrap.js:67:12)
17 verbose stack     at /usr/local/lib/node_modules/npm/lib/install/read-shrinkwrap.js:27:22
17 verbose stack     at tryCatcher (/usr/local/lib/node_modules/npm/node_modules/bluebird/js/release/util.js:16:23)
17 verbose stack     at Holder$2._callFunction (eval at generateHolderClass (/usr/local/lib/node_modules/npm/node_modules/bluebird/js/release/join.js:92:16), <anonymous>:12:44)
17 verbose stack     at Holder$2.checkFulfillment (eval at generateHolderClass (/usr/local/lib/node_modules/npm/node_modules/bluebird/js/release/join.js:92:16), <anonymous>:27:30)
17 verbose stack     at Promise.eval (eval at thenCallback (/usr/local/lib/node_modules/npm/node_modules/bluebird/js/release/join.js:14:16), <anonymous>:4:20)
17 verbose stack     at Promise._settlePromise (/usr/local/lib/node_modules/npm/node_modules/bluebird/js/release/promise.js:571:21)
17 verbose stack     at Promise._settlePromise0 (/usr/local/lib/node_modules/npm/node_modules/bluebird/js/release/promise.js:619:10)
17 verbose stack     at Promise._settlePromises (/usr/local/lib/node_modules/npm/node_modules/bluebird/js/release/promise.js:699:18)
17 verbose stack     at Promise._fulfill (/usr/local/lib/node_modules/npm/node_modules/bluebird/js/release/promise.js:643:18)
17 verbose stack     at Promise._settlePromise (/usr/local/lib/node_modules/npm/node_modules/bluebird/js/release/promise.js:587:21)
17 verbose stack     at Promise._settlePromise0 (/usr/local/lib/node_modules/npm/node_modules/bluebird/js/release/promise.js:619:10)
17 verbose stack     at Promise._settlePromises (/usr/local/lib/node_modules/npm/node_modules/bluebird/js/release/promise.js:699:18)
18 verbose cwd /Users/siliconrob/projects/ercot-market/test
19 verbose Darwin 19.3.0
20 verbose argv "/usr/local/Cellar/node/13.7.0/bin/node" "/usr/local/bin/npm" "install" "--save" "hapi-cron"
21 verbose node v13.7.0
22 verbose npm  v6.13.6
23 error Unexpected end of JSON input while parsing near '...
23 error       }
23 error     }
23 error   }
23 error }
23 error '
24 verbose exit [ 1, true ]
```