### PR TITLE
Feature execute method

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,95 +2,104 @@
  1. Dependencies
  *********************************************************************************/
 
-const Hoek = require('@hapi/hoek');
-const CronJob = require('cron').CronJob;
-const PluginPackage = require('../package.json');
-
-
-/*********************************************************************************
- 2. Internals
- *********************************************************************************/
-
-const internals = {};
-
-internals.trigger = (server, job) => {
-
-    return async () => {
-
-        server.log([PluginPackage.name], job.name);
-
-        const res = await server.inject(job.request);
-
-        /* istanbul ignore else  */
-        if (job.onComplete) {
-            job.onComplete(res.result);
-        }
-    };
-};
-
-internals.onPostStart = (jobs) => {
-
-    return () => {
-
-        for (const key of Object.keys(jobs)) {
-            jobs[key].start();
-        }
-    };
-};
-
-internals.onPreStop = (jobs) => {
-
-    return () => {
-
-        for (const key of Object.keys(jobs)) {
-            jobs[key].stop();
-        }
-    };
-};
-
-
-/*********************************************************************************
- 3. Exports
- *********************************************************************************/
-
-const PluginRegistration = (server, options) => {
-
-    const jobs = {};
-
-    if (!options.jobs || !options.jobs.length) {
-        server.log([PluginPackage.name], 'No cron jobs provided.');
-    }
-    else {
-        options.jobs.forEach((job) => {
-
-            Hoek.assert(!jobs[job.name], 'Job name has already been defined');
-            Hoek.assert(job.name, 'Missing job name');
-            Hoek.assert(job.time, 'Missing job time');
-            Hoek.assert(job.timezone, 'Missing job time zone');
-            Hoek.assert(job.request, 'Missing job request options');
-            Hoek.assert(job.request.url, 'Missing job request url');
-            Hoek.assert(typeof job.onComplete === 'function' || typeof job.onComplete === 'undefined', 'onComplete value must be a function');
-
-            try {
-                jobs[job.name] = new CronJob(job.time, internals.trigger(server, job), null, false, job.timezone);
-            }
-            catch (err) {
-                if (err.message === 'Invalid timezone.') {
-                    Hoek.assert(!err, 'Invalid timezone. See https://momentjs.com/timezone for valid timezones');
-                }
-                else {
-                    Hoek.assert(!err, 'Time is not a cron expression');
-                }
-            }
-        });
-    }
-
-    server.expose('jobs', jobs);
-    server.ext('onPostStart', internals.onPostStart(jobs));
-    server.ext('onPreStop', internals.onPreStop(jobs));
-};
-
-exports.plugin = {
-    register: PluginRegistration,
-    pkg: PluginPackage
-};
+ const Hoek = require('@hapi/hoek');
+ const CronJob = require('cron').CronJob;
+ const PluginPackage = require('../package.json');
+ 
+ /*********************************************************************************
+  2. Internals
+  *********************************************************************************/
+ 
+ const internals = {};
+ 
+ internals.trigger = (server, job) => {
+ 
+     return async () => {
+ 
+         server.log([PluginPackage.name], job.name);
+ 
+         if (job.request) {
+             const res = await server.inject(job.request);
+ 
+             /* istanbul ignore else  */
+             if (job.onComplete) {
+                 job.onComplete(res.result);
+             }
+         } else if (job.execute) {
+             const res = await job.execute();
+ 
+             /* istanbul ignore else  */
+             if (job.onComplete) {
+                 job.onComplete(res);
+             }
+         }
+     };
+ };
+ 
+ internals.onPostStart = (jobs) => {
+ 
+     return () => {
+ 
+         for (const key of Object.keys(jobs)) {
+             jobs[key].start();
+         }
+     };
+ };
+ 
+ internals.onPreStop = (jobs) => {
+ 
+     return () => {
+ 
+         for (const key of Object.keys(jobs)) {
+             jobs[key].stop();
+         }
+     };
+ };
+ 
+ /*********************************************************************************
+  3. Exports
+  *********************************************************************************/
+ 
+ const PluginRegistration = (server, options) => {
+ 
+     const jobs = {};
+ 
+     if (!options.jobs || !options.jobs.length) {
+         server.log([PluginPackage.name], 'No cron jobs provided.');
+     }
+     else {
+         options.jobs.forEach((job) => {
+ 
+             Hoek.assert(!jobs[job.name], 'Job name has already been defined');
+             Hoek.assert(job.name, 'Missing job name');
+             Hoek.assert(job.time, 'Missing job time');
+             Hoek.assert(job.timezone, 'Missing job time zone');
+             Hoek.assert(job.request || job.execute, 'Missing job request options or execute function');
+             if (job.request) {
+                 Hoek.assert(job.request.url, 'Missing job request url');
+             }
+             Hoek.assert(typeof job.onComplete === 'function' || typeof job.onComplete === 'undefined', 'onComplete value must be a function');
+ 
+             try {
+                 jobs[job.name] = new CronJob(job.time, internals.trigger(server, job), null, false, job.timezone);
+             }
+             catch (err) {
+                 if (err.message === 'Invalid timezone.') {
+                     Hoek.assert(!err, 'Invalid timezone. See https://momentjs.com/timezone for valid timezones');
+                 }
+                 else {
+                     Hoek.assert(!err, 'Time is not a cron expression');
+                 }
+             }
+         });
+     }
+ 
+     server.expose('jobs', jobs);
+     server.ext('onPostStart', internals.onPostStart(jobs));
+     server.ext('onPreStop', internals.onPreStop(jobs));
+ };
+ 
+ exports.plugin = {
+     register: PluginRegistration,
+     pkg: PluginPackage
+ };

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,104 +2,106 @@
  1. Dependencies
  *********************************************************************************/
 
- const Hoek = require('@hapi/hoek');
- const CronJob = require('cron').CronJob;
- const PluginPackage = require('../package.json');
- 
- /*********************************************************************************
-  2. Internals
-  *********************************************************************************/
- 
- const internals = {};
- 
- internals.trigger = (server, job) => {
- 
-     return async () => {
- 
-         server.log([PluginPackage.name], job.name);
- 
-         if (job.request) {
-             const res = await server.inject(job.request);
- 
-             /* istanbul ignore else  */
-             if (job.onComplete) {
-                 job.onComplete(res.result);
-             }
-         } else if (job.execute) {
-             const res = await job.execute();
- 
-             /* istanbul ignore else  */
-             if (job.onComplete) {
-                 job.onComplete(res);
-             }
-         }
-     };
- };
- 
- internals.onPostStart = (jobs) => {
- 
-     return () => {
- 
-         for (const key of Object.keys(jobs)) {
-             jobs[key].start();
-         }
-     };
- };
- 
- internals.onPreStop = (jobs) => {
- 
-     return () => {
- 
-         for (const key of Object.keys(jobs)) {
-             jobs[key].stop();
-         }
-     };
- };
- 
- /*********************************************************************************
-  3. Exports
-  *********************************************************************************/
- 
- const PluginRegistration = (server, options) => {
- 
-     const jobs = {};
- 
-     if (!options.jobs || !options.jobs.length) {
-         server.log([PluginPackage.name], 'No cron jobs provided.');
-     }
-     else {
-         options.jobs.forEach((job) => {
- 
-             Hoek.assert(!jobs[job.name], 'Job name has already been defined');
-             Hoek.assert(job.name, 'Missing job name');
-             Hoek.assert(job.time, 'Missing job time');
-             Hoek.assert(job.timezone, 'Missing job time zone');
-             Hoek.assert(job.request || job.execute, 'Missing job request options or execute function');
-             if (job.request) {
-                 Hoek.assert(job.request.url, 'Missing job request url');
-             }
-             Hoek.assert(typeof job.onComplete === 'function' || typeof job.onComplete === 'undefined', 'onComplete value must be a function');
- 
-             try {
-                 jobs[job.name] = new CronJob(job.time, internals.trigger(server, job), null, false, job.timezone);
-             }
-             catch (err) {
-                 if (err.message === 'Invalid timezone.') {
-                     Hoek.assert(!err, 'Invalid timezone. See https://momentjs.com/timezone for valid timezones');
-                 }
-                 else {
-                     Hoek.assert(!err, 'Time is not a cron expression');
-                 }
-             }
-         });
-     }
- 
-     server.expose('jobs', jobs);
-     server.ext('onPostStart', internals.onPostStart(jobs));
-     server.ext('onPreStop', internals.onPreStop(jobs));
- };
- 
- exports.plugin = {
-     register: PluginRegistration,
-     pkg: PluginPackage
- };
+const Hoek = require('@hapi/hoek');
+const CronJob = require('cron').CronJob;
+const PluginPackage = require('../package.json');
+
+/*********************************************************************************
+ 2. Internals
+ *********************************************************************************/
+
+const internals = {};
+
+internals.trigger = (server, job) => {
+
+    return async () => {
+
+        server.log([PluginPackage.name], job.name);
+
+        /* istanbul ignore else */
+        if (job.request) {
+            const res = await server.inject(job.request);
+            /* istanbul ignore else  */
+            if (job.onComplete) {
+                job.onComplete(res.result);
+            }
+        }
+        else if (job.execute) {
+            const res = await job.execute();
+
+            /* istanbul ignore else  */
+            if (job.onComplete) {
+                job.onComplete(res);
+            }
+        }
+    };
+};
+
+internals.onPostStart = (jobs) => {
+
+    return () => {
+
+        for (const key of Object.keys(jobs)) {
+            jobs[key].start();
+        }
+    };
+};
+
+internals.onPreStop = (jobs) => {
+
+    return () => {
+
+        for (const key of Object.keys(jobs)) {
+            jobs[key].stop();
+        }
+    };
+};
+
+/*********************************************************************************
+ 3. Exports
+ *********************************************************************************/
+
+const PluginRegistration = (server, options) => {
+
+    const jobs = {};
+
+    if (!options.jobs || !options.jobs.length) {
+        server.log([PluginPackage.name], 'No cron jobs provided.');
+    }
+    else {
+        options.jobs.forEach((job) => {
+
+            Hoek.assert(!jobs[job.name], 'Job name has already been defined');
+            Hoek.assert(job.name, 'Missing job name');
+            Hoek.assert(job.time, 'Missing job time');
+            Hoek.assert(job.timezone, 'Missing job time zone');
+            Hoek.assert(job.request || job.execute, 'Missing job request options or execute function');
+            if (job.request) {
+                Hoek.assert(job.request.url, 'Missing job request url');
+            }
+
+            Hoek.assert(typeof job.onComplete === 'function' || typeof job.onComplete === 'undefined', 'onComplete value must be a function');
+
+            try {
+                jobs[job.name] = new CronJob(job.time, internals.trigger(server, job), null, false, job.timezone);
+            }
+            catch (err) {
+                if (err.message === 'Invalid timezone.') {
+                    Hoek.assert(!err, 'Invalid timezone. See https://momentjs.com/timezone for valid timezones');
+                }
+                else {
+                    Hoek.assert(!err, 'Time is not a cron expression');
+                }
+            }
+        });
+    }
+
+    server.expose('jobs', jobs);
+    server.ext('onPostStart', internals.onPostStart(jobs));
+    server.ext('onPreStop', internals.onPreStop(jobs));
+};
+
+exports.plugin = {
+    register: PluginRegistration,
+    pkg: PluginPackage
+};


### PR DESCRIPTION
### Description

This pull request adds support for executing methods directly in cron jobs configured with the `hapi-cron` plugin. 

### Changes
- Added an `execute` option to the job configuration, allowing users to specify a function to be executed at the scheduled time.
- Modified `internals.trigger` to handle the `execute` option in addition to the existing `request` option.
- Updated validation to ensure either `job.request` or `job.execute` is provided.

### Example Usage
```javascript
const server = Hapi.server({ port: 3000, host: 'localhost' });

const myFunction = async () => {
    console.log('myFunction was called!');
    return 'Function execution result';
};

await server.register({
    plugin: HapiCron,
    options: {
        jobs: [
            {
                name: 'myFunctionCron',
                time: '*/10 * * * * *', // every 10 seconds
                timezone: 'America/Vancouver',
                execute: myFunction,
                onComplete: (result) => {
                    console.log('Job completed with result:', result);
                }
            }
        ]
    }
});